### PR TITLE
Make cloud-config/cacert volume/volumeMounts configurable

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v1.19.0"
+appVersion: v1.19.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.2.1
+version: 1.2.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag }}"
+          image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
           args:
             - /bin/cinder-csi-plugin
@@ -95,13 +95,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-            - name: cacert
-              mountPath: /etc/cacert
-              readOnly: true
+            {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
       volumes:
-        - name: cacert
-          hostPath:
-            path: /etc/cacert
-            type: Directory
         - name: socket-dir
           emptyDir:
+        {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -47,7 +47,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag }}"
+          image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
           args:
             - /bin/cinder-csi-plugin
@@ -73,14 +73,8 @@ spec:
             - name: pods-probe-dir
               mountPath: /dev
               mountPropagation: "HostToContainer"
-            - name: cacert
-              mountPath: /etc/cacert
-              readOnly: true
+            {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
       volumes:
-        - name: cacert
-          hostPath:
-            path: /etc/cacert
-            type: Directory
         - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
@@ -101,3 +95,4 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/secret.yaml
+++ b/charts/cinder-csi-plugin/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  namespace: {{ .Release.NameSpace }}
+type: Opaque
+stringData:
+  {{ .Values.secret.data | toYaml | trimSuffix "\n" | nindent 2 }}
+{{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -30,8 +30,36 @@ csi:
   plugin:
     image:
       repository: docker.io/k8scloudprovider/cinder-csi-plugin
-      tag: v1.19.0
       pullPolicy: IfNotPresent
+      tag:  # defaults to .Chart.AppVersion
+    volumes:
+      - name: cacert
+        hostPath:
+          path: /etc/cacert
+      - name: cloud-config
+        hostPath:
+          path: /etc/kubernetes
+        # secret:
+        #   secretName: cinder-csi-cloud-config
+    volumeMounts:
+      - name: cacert
+        mountPath: /etc/cacert
+        readOnly: true
+      - name: cloud-config
+        mountPath: /etc/kubernetes
+        readOnly: true
+
+secret:
+#  name: cinder-csi-cloud-config
+#  data:
+#    cloud-config: |-
+#      [Global]
+#      auth-url=http://openstack-control-plane
+#      user-id=user-id
+#      password=password
+#      trust-id=trust-id
+#      region=RegionOne
+#      ca-file=/etc/cacert/ca-bundle.crt
 
 storageClass:
   enabled: true

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: latest
+appVersion: v1.19.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 0.2.0
+version: 0.2.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -65,7 +65,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag }}"
+          image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --v=5

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag }}"
+          image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --v=5

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullNameOverride: ""
+
 # Base name of the CSI Manila driver
 driverName: manila.csi.openstack.org
 
@@ -31,8 +34,8 @@ csimanila:
   # Image spec
   image:
     repository: k8scloudprovider/manila-csi-plugin
-    tag: v1.19.0
     pullPolicy: IfNotPresent
+    tag:  # defaults to .Chart.AppVersion
 
 # DeamonSet deployment
 nodeplugin:
@@ -79,6 +82,3 @@ controllerplugin:
   affinity: {}
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
-
-# Override the default app name using nameOverride
-# nameOverride: some-other-name


### PR DESCRIPTION
Some Kubernetes deployment software like OpenStack Magnum place
ca-bundle.crt under a different path. Other users may want to use a
secret for OpenStack cloud config rather than cloud-config on the host.

Also derive image tag from appVersion from Chart.yaml.

(cherry picked from commit 62e1285605d0069be8eb30756ad272d37d92c509)

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
