### PR TITLE
[occm] Support LB providers that don't implement bulk-update API calls

### DIFF
--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -57,4 +57,8 @@ type octaviaConfig struct {
 	// (Optional) Flavor ID to create the load balancer.
 	// If empty, the default flavor will be used.
 	FlavorID string `mapstructure:"flavor-id"`
+
+	// (Optional) If the ingress controller should use legacy API calls when creating and updating the load balancer
+	// Default is false.
+	UseLegacyAPICalls bool `mapstructure:"use-legacy-api-calls"`
 }

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -456,6 +456,20 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
 	}
 
+	if os.config.Octavia.UseLegacyAPICalls {
+		// Serially update pool members
+		err = openstackutil.SeriallyReconcilePoolMembers(os.Octavia, pool, *nodePort, lbID, nodes)
+		if err != nil {
+			return nil, fmt.Errorf("error reconciling pool members for pool %s: %v", pool.ID, err)
+		}
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+		logger.Info("pool members updated")
+
+		return &pool.ID, nil
+	}
 	// Batch update pool members
 	var members []pools.BatchUpdateMemberOpts
 	for _, node := range nodes {

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -102,6 +102,7 @@ type LoadBalancerOpts struct {
 	IngressHostnameSuffix string              `gcfg:"ingress-hostname-suffix"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
 	MaxSharedLB           int                 `gcfg:"max-shared-lb"`           //  Number of Services in maximum can share a single load balancer. Default 2
 	ContainerStore        string              `gcfg:"container-store"`         // Used to specify the store of the tls-container-ref
+	UseLegacyAPICalls     bool                `gcfg:"use-legacy-api-calls"`    // If true, use legacy API calls to Octavia endpoints
 	// revive:disable:var-naming
 	TlsContainerRef string `gcfg:"default-tls-container-ref"` //  reference to a tls container
 	// revive:enable:var-naming
@@ -204,6 +205,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.IngressHostnameSuffix = defaultProxyHostnameSuffix
 	cfg.LoadBalancer.TlsContainerRef = ""
 	cfg.LoadBalancer.ContainerStore = "barbican"
+	cfg.LoadBalancer.UseLegacyAPICalls = false
 	cfg.LoadBalancer.MaxSharedLB = 2
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/pagination"
 	version "github.com/hashicorp/go-version"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	klog "k8s.io/klog/v2"
 
@@ -556,6 +557,101 @@ func DeletePool(client *gophercloud.ServiceClient, poolID string, lbID string) e
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting pool: %v", lbID, err)
 	}
 
+	return nil
+}
+
+func memberExists(members []pools.Member, addr string, port int) bool {
+	for _, member := range members {
+		if member.Address == addr && member.ProtocolPort == port {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cutString makes sure the string length doesn't exceed 255, which is usually the maximum string length in OpenStack.
+func cutString(original string) string {
+	ret := original
+	if len(original) > 255 {
+		ret = original[:255]
+	}
+	return ret
+}
+
+func popMember(members []pools.Member, addr string, port int) []pools.Member {
+	for i, member := range members {
+		if member.Address == addr && member.ProtocolPort == port {
+			members[i] = members[len(members)-1]
+			members = members[:len(members)-1]
+		}
+	}
+
+	return members
+}
+
+func getNodeAddressForLB(node *apiv1.Node) (string, error) {
+	addrs := node.Status.Addresses
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("no address found for host")
+	}
+
+	for _, addr := range addrs {
+		if addr.Type == apiv1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+
+	return addrs[0].Address, nil
+}
+
+func SeriallyReconcilePoolMembers(client *gophercloud.ServiceClient, pool *pools.Pool, nodePort int, lbID string, nodes []*apiv1.Node) error {
+
+	members, err := GetMembersbyPool(client, pool.ID)
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		return fmt.Errorf("error getting pool members %s: %v", pool.ID, err)
+	}
+
+	for _, node := range nodes {
+		addr, err := getNodeAddressForLB(node)
+		if err != nil {
+			if err == cpoerrors.ErrNotFound {
+				// Node failure, do not create member
+				klog.Warning("Failed to create LB pool member for node %s: %v", node.Name, err)
+				continue
+			} else {
+				return fmt.Errorf("error getting address for node %s: %v", node.Name, err)
+			}
+		}
+		if !memberExists(members, addr, nodePort) {
+			klog.V(2).Infof("Creating member for pool %s", pool.ID)
+			_, err := pools.CreateMember(client, pool.ID, pools.CreateMemberOpts{
+				Name:         cutString(fmt.Sprintf("member_%s_%s_%d", node.Name, addr, nodePort)),
+				ProtocolPort: nodePort,
+				Address:      addr,
+			}).Extract()
+			if err != nil {
+				return fmt.Errorf("error creating LB pool member for node: %s, %v", node.Name, err)
+			}
+			if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
+				return err
+			}
+		} else {
+			// After all members have been processed, remaining members are deleted as obsolete.
+			members = popMember(members, addr, nodePort)
+		}
+		klog.V(2).Infof("Ensured pool %s has member for %s at %s", pool.ID, node.Name, addr)
+	}
+	for _, member := range members {
+		klog.V(2).Infof("Deleting obsolete member %s for pool %s address %s", member.ID, pool.ID, member.Address)
+		err := pools.DeleteMember(client, pool.ID, member.ID).ExtractErr()
+		if err != nil && !cpoerrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting obsolete member %s for pool %s address %s: %v", member.ID, pool.ID, member.Address, err)
+		}
+		if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some loadbalancer providers (like `vmwareedge`) don't implement an API for creating fully-populated loadbalancers, or for bulk-updating loadbalancer pool members. Although vmwareedge isn't officially supported by OCCM this patch allows loadbalancers to be created, updated and deleted on VMWare Integrated OpenStack (VIO), specifically tested on VIO7.

**Which issue this PR fixes(if applicable)**:
N/A

**Special notes for reviewers**:
As this new functionality results in many more OpenStack API calls, and is not required for the more widely deployed Amphora and OVN cases, it is gated behind a cloud-config variable: 

```
[LoadBalancer]
lb-provider=vmwareedge
use-legacy-api-calls=true
```

**Release note**:
```release-note
[openstack-cloud-controller-manager] Add support for additional loadbalancer providers
Added support for loadbalancer providers that do not implement an API for creating fully-populated loadbalancers, or bulk-updating loadbalancer pool members.
```
